### PR TITLE
{appservice-kube} Ensure compatibility with upcoming CLI version

### DIFF
--- a/src/appservice-kube/HISTORY.rst
+++ b/src/appservice-kube/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.1.3
+++++++
+* Ensure compatibility of 'az webapp create' with CLI version 2.33.0
+
 0.1.2
 ++++++
 * Allow passing custom locations by name if in the same resource group as the app/plan

--- a/src/appservice-kube/azext_appservice_kube/azext_metadata.json
+++ b/src/appservice-kube/azext_appservice_kube/azext_metadata.json
@@ -1,4 +1,4 @@
 {
     "azext.isPreview": true,
-    "azext.minCliCoreVersion": "2.26.0"
+    "azext.minCliCoreVersion": "2.33.0"
 }

--- a/src/appservice-kube/setup.py
+++ b/src/appservice-kube/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '0.1.2'
+VERSION = '0.1.3'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
The upcoming CLI version will have this feature: https://github.com/Azure/azure-cli/pull/21057, which slightly changes some interfaces that were used in the `az webapp create` implementation here. This PR ensures that the  `az webapp create` command will remain functional with upcoming CLI version `2.33.0`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [X] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [X] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [X] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
